### PR TITLE
詳細ボタンの形崩れの修正

### DIFF
--- a/src/pages/styles/EventList.css
+++ b/src/pages/styles/EventList.css
@@ -120,23 +120,30 @@
     font-size: 1.1rem;
   }
 
-  .button-group {
-    flex-direction: column;
-    align-items: center;
-    gap: 0.5rem;
-  }
-
   .detail-button,
   .favorite-button {
-    width: 90%;
-    height: 40px;
-    max-width: 220px;
-    font-size: 0.85rem;
-    padding: 0.6rem 1rem;
+    max-width: 120px;      /* 幅上限も小さく */
+    height: 36px;          /* 高さを少し小さく */
+    font-size: 0.75rem;    /* フォントサイズも少し小さめ */
+    padding: 0.5rem 0.8rem;
   }
 
   .category-filter select {
-    width: 60%;
+    width: 80%;
+    max-width: 300px;
     font-size: 0.95rem;
+    margin-top: 0.5rem;
+    margin-left: 0;
+  }
+
+  .pagination {
+    margin-top: 2rem;
+    margin-bottom: 8rem;
+  }
+
+  .pagination button {
+    font-size: 0.9rem;
+    padding: 0.4rem 0.8rem;
   }
 }
+

--- a/src/pages/styles/Favorites.css
+++ b/src/pages/styles/Favorites.css
@@ -95,12 +95,6 @@
       font-size: 15px;
     }
   
-    .button-group {
-      flex-direction: column;
-      align-items: center;
-      gap: 0.5rem;
-    }
-  
     .pagination {
       margin-top: 2rem;
       margin-bottom: 8rem;

--- a/src/pages/styles/TalentBank.css
+++ b/src/pages/styles/TalentBank.css
@@ -140,31 +140,18 @@
     font-size: 1.1rem;
   }
 
-  .button-group {
-    flex-direction: column;
-    align-items: center;
-    gap: 0.5rem;
-  }
-
   .detail-button,
   .favorite-button {
-    width: 90%;
-    height: 40px;
-    max-width: 220px;
-    font-size: 0.85rem;
-    padding: 0.6rem 1rem;
+    max-width: 120px;
+    height: 36px;    
+    font-size: 0.75rem;
+    padding: 0.5rem 0.8rem;
   }
 
   .register-button {
     width: 90%;
     max-width: 240px;
     font-size: 0.95rem;
-  }
-
-  .category-filter {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
   }
 
   .category-filter select {
@@ -176,15 +163,12 @@
   }
 
   .pagination {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 0.5rem;
     margin-top: 2rem;
+    margin-bottom: 8rem;
   }
 
   .pagination button {
+    font-size: 0.9rem;
     padding: 0.4rem 0.8rem;
-    font-size: 0.85rem;
   }
 }


### PR DESCRIPTION
**概要**
詳細ボタンの形崩れの修正

**内容**
詳細ボタンについて、画面幅が狭まると形が崩れてしまっていたため修正